### PR TITLE
Fixed a crash bug where rectangular texture were incorrectly sized

### DIFF
--- a/src/AtlasTexturePackerLib/AtlasCreator.cs
+++ b/src/AtlasTexturePackerLib/AtlasCreator.cs
@@ -187,12 +187,13 @@ namespace AtlasTexturePacker.Library
                 if (imageRef != null)
                 {
                     
-                    Color[] data = imageRef.GetPixels();
+                    PixelMap data = imageRef.GetPixels();
                     for (int x = 0; x < imageRef.Width; ++x)
                     {
                         for (int y = 0; y < imageRef.Height; ++y)
                         {
-                            target.SetPixel(x + (int)rc.X, y + (int)rc.Y, data[x + y * imageRef.Width]);
+                            //target.SetPixel(x + (int)rc.X, y + (int)rc.Y, data[x + y]);// * imageRef.Width]);
+                            target.SetPixel(x + (int)rc.X, y + (int)rc.Y, data.GetPixel(x, y));
                         }
                     }
                     // Artificial texture bleeding!
@@ -201,12 +202,12 @@ namespace AtlasTexturePacker.Library
                         for (int y = 0; y < imageRef.Height; ++y)
                         {
                             int x = imageRef.Width - 1;
-                            target.SetPixel(x + (int)rc.X + TEXTURE_PADDING, y + (int)rc.Y, data[x + y * imageRef.Width]);
+                            target.SetPixel(x + (int)rc.X + TEXTURE_PADDING, y + (int)rc.Y, data.GetPixel(x, y));
                         }
                         for (int x = 0; x < imageRef.Width; ++x)
                         {
                             int y = imageRef.Height - 1;
-                            target.SetPixel(x + (int)rc.X, y + (int)rc.Y + TEXTURE_PADDING, data[x + y * imageRef.Width]);
+                            target.SetPixel(x + (int)rc.X, y + (int)rc.Y + TEXTURE_PADDING, data.GetPixel(x, y));
                         }
                     }
                 }
@@ -241,8 +242,8 @@ namespace AtlasTexturePacker.Library
         public static Atlas[] CreateAtlas(string name, BitmapExtended[] textures, Atlas startWith = null)
         {
             // Rotate images
-            for (int i = 0; i < textures.Length; ++i)
-                textures[i].RotateFlip(RotateFlipType.Rotate90FlipNone);
+            //for (int i = 0; i < textures.Length; ++i)
+            //    textures[i].RotateFlip(RotateFlipType.Rotate90FlipNone);
 
             List<BitmapExtended> toProcess = new List<BitmapExtended>();
             toProcess.AddRange(textures);

--- a/src/AtlasTexturePackerLib/AtlasTexturePacker.Library.csproj
+++ b/src/AtlasTexturePackerLib/AtlasTexturePacker.Library.csproj
@@ -44,6 +44,7 @@
     <Compile Include="AtlasCreatorDescriptors.cs" />
     <Compile Include="AtlasCreatorTrim.cs" />
     <Compile Include="BitmapExtended.cs" />
+    <Compile Include="PixelMap.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rect.cs" />
   </ItemGroup>

--- a/src/AtlasTexturePackerLib/BitmapExtended.cs
+++ b/src/AtlasTexturePackerLib/BitmapExtended.cs
@@ -48,26 +48,26 @@ namespace AtlasTexturePacker.Library
             _bitmap = new Bitmap(width, height);
         }
 
-        public Color[] GetPixels()
+        public PixelMap GetPixels()
         {
-            List<Color> pixels = new List<Color>();
+            PixelMap map = new PixelMap(_bitmap.Width, _bitmap.Height);
 
-            for (int x = _bitmap.Height - 1; x >= 0; --x)
+            for(int x = 0; x < _bitmap.Width; ++x) //(int x = _bitmap.Width - 1; x >= 0; --x)
             {
-                for (int y = 0; y < _bitmap.Width; ++y)
+                for (int y = 0; y < _bitmap.Height; ++y)
                 {
-                    pixels.Add(_bitmap.GetPixel(x, y));
+                    map.SetPixel(x, y, _bitmap.GetPixel(x, y));
                 }
             }
 
-            return pixels.ToArray();
+            return map;
         }
-
+        /*
         public void RotateFlip(RotateFlipType rotation)
         {
             _bitmap.RotateFlip(rotation);
         }
-
+        */
         public void SetPixel(int x, int y, Color color)
         {
             _bitmap.SetPixel(x, y, color);

--- a/src/AtlasTexturePackerLib/PixelMap.cs
+++ b/src/AtlasTexturePackerLib/PixelMap.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Drawing;
+
+namespace AtlasTexturePacker.Library
+{
+    public class PixelMap
+    {
+        Color[,] _Pixels = null;
+
+        public PixelMap(int width, int height)
+        {
+            _Pixels = new Color[width, height];
+        }
+
+        public int Width
+        {
+            get
+            {
+                return _Pixels.GetLength(0);
+            }
+        }
+
+        public int Height
+        {
+            get
+            {
+                return _Pixels.GetLength(1);
+            }
+        }
+
+        public Color GetPixel(int x, int y)
+        {
+            if (x > _Pixels.GetLength(0) || x < 0)
+                throw new ArgumentOutOfRangeException("x must be >= 0 and < width");
+
+            if (y > _Pixels.GetLength(1) || y < 0)
+                throw new ArgumentOutOfRangeException("y must be >= 0 and < height");
+
+            return _Pixels[x, y];
+        }
+
+        public void SetPixel(int x, int y, Color color)
+        {
+            if (x > _Pixels.GetLength(0) || x < 0)
+                throw new ArgumentOutOfRangeException("x must be >= 0 and < width");
+
+            if (y > _Pixels.GetLength(1) || y < 0)
+                throw new ArgumentOutOfRangeException("y must be >= 0 and < height");
+
+            _Pixels[x, y] = color;
+        }
+    }
+}


### PR DESCRIPTION
made a mistake copying texture while building the atlas. Fixed that mistake by creating a PixelMap class.
